### PR TITLE
Fix ValueError when order param is blank

### DIFF
--- a/admin_reports/views.py
+++ b/admin_reports/views.py
@@ -64,8 +64,9 @@ class ReportList(object):
 
     def _get_ordering(self):
         ordering = []
-        if ORDER_VAR in self.params:
-            sort_values = self.params.get(ORDER_VAR).split('.')
+        order_params = self.params.get(ORDER_VAR)
+        if order_params:
+            sort_values = order_params.split('.')
             fields = self.report.get_fields()
             for o in sort_values:
                 if o.startswith('-'):


### PR DESCRIPTION
> ValueError at /admin/myreport/
> invalid literal for int() with base 10: ''
> Request Method:	GET
> Request URL:	`http://localhost/admin/myreport/?o=`
> Django Version:	1.10.3
> Exception Type:	ValueError
> Exception Value:	
> invalid literal for int() with base 10: ''
> Exception Location:	/usr/local/lib/python2.7/site-packages/admin_reports/admin_reports/views.py in _get_ordering, line 74
> Python Executable:	/usr/local/bin/python
> Python Version:	2.7.13