### PR TITLE
Fix for request being passed as sort_params parameter to Report __init__

### DIFF
--- a/admin_reports/views.py
+++ b/admin_reports/views.py
@@ -245,7 +245,8 @@ class ReportView(TemplateView, FormMixin):
         }
         return render(self.request, 'admin/export.html', ctx)
 
-    def post(self, *args, **kwargs):
+    def post(self, request, *args, **kwargs):
+        # TODO: FIXME: you shouldn't just pass request args to Report __init__() this is straight up dangerous.
         self.report = self.report_class(*args, **kwargs)
         if not self.report.has_permission(self.request):
             raise PermissionDenied()


### PR DESCRIPTION
more work is required here. The report_class should be initialized
properly.
This fixes issue #18 